### PR TITLE
change made but current version od http4s 0.23.11.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,9 +46,9 @@ object Dependencies {
     val doobieQuill     = "org.polyvariant" %% "doobie-quill" % V.doobieQuill
     val flyway          = "org.flywaydb"          % "flyway-core"      % V.flyway
     val http4sCirce     = http4sLib("http4s-circe")
-    val http4sClient    = http4sLib("http4s-blaze-client")
+    val http4sClient    = http4sLib("http4s-ember-client")
     val http4sDsl       = http4sLib("http4s-dsl")
-    val http4sServer    = http4sLib("http4s-blaze-server")
+    val http4sServer    = http4sLib("http4s-ember-server")
     val jwtCirce        = "com.github.jwt-scala" %% "jwt-circe"        % V.jwtCirce
     val logback         = "ch.qos.logback"        % "logback-classic"  % V.Logback
     val mUnit           = mUnitLib("munit")

--- a/src/main/scala/taskforce/common/errors.scala
+++ b/src/main/scala/taskforce/common/errors.scala
@@ -10,5 +10,6 @@ object errors {
   case class NotFound(resourceId: String) extends NoStackTrace
 
   case class InvalidQueryParam(s: String) extends NoStackTrace
+  case class InvalidPort(port:Int) extends NoStackTrace
 
 }


### PR DESCRIPTION
throws some errors to logs:

 root[ERROR] org.http4s.ember.core.EmberException$EmptyStream: Cannot Parse Empty Stream
root[ERROR]     at org.http4s.ember.core.Parser$MessageP$.$anonfun$recurseFind$2(Parser.scala:50)
root[ERROR]     at main$ @ taskforce.Main$.main(Main.scala:17)
root[ERROR]     at get @ org.http4s.ember.server.internal.Shutdown$$anon$1.<init>(Shutdown.scala:74)
root[ERROR]     at complete @ org.http4s.ember.server.internal.Shutdown$$anon$1.<init>(Shutdown.scala:56)